### PR TITLE
chore: add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-interface-record-store
-=====================
+⛔️ DEPRECATED: interface-record-store is now included in [ipfs/interface-datastore](https://github.com/ipfs/interface-datastore)
+======
+
+# interface-record-store
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)
 [![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)


### PR DESCRIPTION
In the context of [libp2p/js-libp2p#383](https://github.com/libp2p/js-libp2p/issues/383), a deprecation notice is added.

Needs:

- [ ] npm deprecation notice

After merged, the repo must be archived (I do not have permissions to do it)